### PR TITLE
fix(deps): migrate from PyPDF2 to pypdf (CVE-2023-36464)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ The application follows object-oriented design with clear separation of concerns
 Uses uv for package management. Dependencies are declared in `pyproject.toml` and include:
 - Google API libraries (Drive, OAuth, modern Google Gen AI SDK)
 - LLM provider SDKs (anthropic, openai, requests for X.AI)
-- PDF processing (PyPDF2)
+- PDF processing (pypdf)
 - Utilities (python-dotenv, base64, logging)
 
 All dependencies are automatically managed by uv from `pyproject.toml` when running the app or the test suite. The Google integration uses the latest Google Gen AI SDK (google-genai) instead of the deprecated Vertex AI SDK, eliminating deprecation warnings. (`update_models.py` remains a standalone PEP 723 inline-metadata script.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "google-genai>=0.1.0",
     "anthropic>=0.7.0",
     "openai>=1.0.0",
-    "PyPDF2==3.0.1",
+    "pypdf>=4.0.0",
     "requests>=2.31.0",
     "python-dotenv==1.2.2",
     "types-requests",

--- a/scan_namer.py
+++ b/scan_namer.py
@@ -26,7 +26,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload
-import PyPDF2
+import pypdf
 from dotenv import load_dotenv
 import pytesseract
 from pdf2image import convert_from_path
@@ -416,7 +416,7 @@ class PDFProcessor:
         """Get the number of pages in a PDF."""
         try:
             with open(pdf_path, "rb") as f:
-                reader = PyPDF2.PdfReader(f)
+                reader = pypdf.PdfReader(f)
                 return len(reader.pages)
         except Exception as e:
             logging.error(f"Error reading PDF {pdf_path}: {e}")
@@ -435,8 +435,8 @@ class PDFProcessor:
 
         try:
             with open(input_path, "rb") as input_file:
-                reader = PyPDF2.PdfReader(input_file)
-                writer = PyPDF2.PdfWriter()
+                reader = pypdf.PdfReader(input_file)
+                writer = pypdf.PdfWriter()
 
                 pages_to_extract = min(num_pages, len(reader.pages))
                 for i in range(pages_to_extract):
@@ -463,7 +463,7 @@ class PDFProcessor:
         try:
             text_content = []
             with open(pdf_path, "rb") as f:
-                reader = PyPDF2.PdfReader(f)
+                reader = pypdf.PdfReader(f)
                 pages_to_process = min(max_pages, len(reader.pages))
 
                 for i in range(pages_to_process):
@@ -502,7 +502,7 @@ class PDFProcessor:
             page_count = 0
 
             with open(pdf_path, "rb") as f:
-                reader = PyPDF2.PdfReader(f)
+                reader = pypdf.PdfReader(f)
                 page_count = len(reader.pages)
 
                 for page in reader.pages:
@@ -564,8 +564,8 @@ class PDFProcessor:
         try:
             # Read original PDF
             with open(original_pdf_path, "rb") as input_file:
-                reader = PyPDF2.PdfReader(input_file)
-                writer = PyPDF2.PdfWriter()
+                reader = pypdf.PdfReader(input_file)
+                writer = pypdf.PdfWriter()
 
                 # Process each page
                 for page_num, page in enumerate(reader.pages):
@@ -573,7 +573,7 @@ class PDFProcessor:
                     writer.add_page(page)
 
                     # If we have OCR text for this page, we'll add it as metadata
-                    # Note: PyPDF2 doesn't directly support invisible text layers,
+                    # Note: pypdf does not directly support invisible text layers,
                     # but we can add the text to the page's content stream in a way
                     # that makes it searchable
                     if page_num < len(ocr_text_list) and ocr_text_list[page_num]:

--- a/tests/test_pdf_and_url.py
+++ b/tests/test_pdf_and_url.py
@@ -1,4 +1,47 @@
+import pypdf
+
 import scan_namer
+
+
+def _write_pdf(path, num_pages, width=200, height=200):
+    """Create a real multi-page PDF on disk using pypdf."""
+    writer = pypdf.PdfWriter()
+    for _ in range(num_pages):
+        writer.add_blank_page(width=width, height=height)
+    with open(path, "wb") as f:
+        writer.write(f)
+    return str(path)
+
+
+def test_get_page_count_roundtrip(config, tmp_path):
+    # Exercises the pypdf-backed PdfReader path end-to-end.
+    pdf_path = _write_pdf(tmp_path / "five.pdf", 5)
+    proc = scan_namer.PDFProcessor(config)
+    assert proc.get_page_count(pdf_path) == 5
+
+
+def test_extract_pages_roundtrip(config, tmp_path):
+    # Writer.add_page + write, then re-read with PdfReader: full migrated path.
+    src = _write_pdf(tmp_path / "src.pdf", 5)
+    out = tmp_path / "out.pdf"
+    proc = scan_namer.PDFProcessor(config)
+    assert proc.extract_pages(src, str(out), num_pages=2) is True
+    assert proc.get_page_count(str(out)) == 2
+
+
+def test_extract_text_roundtrip_returns_str(config, tmp_path):
+    # Blank pages carry no text; the call must still succeed and return a str.
+    pdf_path = _write_pdf(tmp_path / "blank.pdf", 2)
+    proc = scan_namer.PDFProcessor(config)
+    assert proc.extract_text(pdf_path) == ""
+
+
+def test_get_page_count_bad_file_returns_zero(config, tmp_path):
+    # Error path: a non-PDF file should be handled, not raise.
+    bad = tmp_path / "not.pdf"
+    bad.write_text("this is not a pdf")
+    proc = scan_namer.PDFProcessor(config)
+    assert proc.get_page_count(str(bad)) == 0
 
 
 def test_should_extract_below_threshold(config):

--- a/uv.lock
+++ b/uv.lock
@@ -982,12 +982,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pypdf2"
-version = "3.0.1"
+name = "pypdf"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]
@@ -1071,7 +1074,7 @@ dependencies = [
     { name = "openai" },
     { name = "pdf2image" },
     { name = "pillow" },
-    { name = "pypdf2" },
+    { name = "pypdf" },
     { name = "pytesseract" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -1093,7 +1096,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pdf2image", specifier = "==1.17.0" },
     { name = "pillow", specifier = ">=10.0.0" },
-    { name = "pypdf2", specifier = "==3.0.1" },
+    { name = "pypdf", specifier = ">=4.0.0" },
     { name = "pytesseract", specifier = "==0.3.13" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "requests", specifier = ">=2.31.0" },


### PR DESCRIPTION
## Why
PyPDF2 3.0.1 — the project's pinned version and PyPDF2's **final release** — is affected by **[CVE-2023-36464](https://github.com/advisories/GHSA-4vvm-4w3v-6mr8)** (medium): a denial-of-service infinite loop in `__parse_content_stream`. Per the GitHub Advisory, PyPDF2's patched version is **None** — the only remediation is migrating to the successor library, **pypdf**, where the fix landed in 3.9.0.

## What changed
- **pyproject.toml**: `PyPDF2==3.0.1` → `pypdf>=4.0.0` (resolves to 6.14.2)
- **scan_namer.py**: `import PyPDF2` → `import pypdf`; `PyPDF2.PdfReader`/`PdfWriter` → `pypdf.PdfReader`/`PdfWriter`. The modern API used here (`.pages`, `extract_text`, `add_page`, `add_metadata`, `write`) is identical across PyPDF2 3.0.x and pypdf 6.x, so this is a namespace-only swap.
- **tests**: added round-trip tests that build a real multi-page PDF and exercise `get_page_count`, `extract_pages`, `extract_text`, and the error path through the migrated code.
- **CLAUDE.md**: notes pypdf as the PDF library.

## Verification
- `uv run pytest`: **146 passed** (was 142; +4 new). PyPDF2 deprecation warning gone.
- **pip-audit**: no known vulnerabilities.
- **safety**: no known vulnerabilities (previously flagged PyPDF2 3.0.1 / CVE-2023-36464).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tew5KURq7nUqYPvHTXDmDA